### PR TITLE
Dynamic number of bots

### DIFF
--- a/cleverbutts.js
+++ b/cleverbutts.js
@@ -24,7 +24,7 @@ var i = 0, callback = function callback(resp) {
       newtext = undefined;
   		}
     CBots[i].write(toWrite, callback);
-   
+
     DBots[i = ((i + 1) % DBots.length)].sendMessage(config.botChannel, toWrite);
   }, config.bot_speed);
   DBots[i].stopTyping(config.botChannel);

--- a/cleverbutts.js
+++ b/cleverbutts.js
@@ -1,45 +1,52 @@
 var Cleverbot = require('cleverbot-node')
-    , Discordbot = require("discord.js")
-    , fs = require("fs")
-    , config = require("./config.json")
-    , DBots = [new Discordbot.Client(),new Discordbot.Client(),new Discordbot.Client(),new Discordbot.Client(),new Discordbot.Client()]
-    , randombot = Math.floor(Math.random() * config.bots_hosting)
-    , newtext = undefined
-    , lastMessage = "Hello there!"
-    , voters = []
-    , votes = 0;
+  , Discordbot = require("discord.js")
+  , fs = require("fs")
+  , config = require("./config.json")
+  , DBots = []
+  , CBots = []
+  , randombot = Math.floor(Math.random() * (config.bots.length - 1))
+  , newtext = undefined
+  , lastMessage = "Hello there!"
+  , voters = []
+  , votes = 0;
 
-var CBots = [new Cleverbot,new Cleverbot,new Cleverbot,new Cleverbot] , i = 0 , callback = function callback(resp){
-setTimeout(function(str1, str2) {
-  DBots[i].startTyping(config.botChannel);
-		var toWrite = resp['message'];
-  		if(newtext) {
-  			toWrite = newtext;
-  			newtext = undefined;
+for (var ii = 0; ii < config.bots.length; ii++) {
+  DBots.push(new Discordbot.Client())
+  CBots.push(new Cleverbot)
+}
+
+var i = 0, callback = function callback(resp) {
+  setTimeout(function (str1, str2) {
+    DBots[i].startTyping(config.botChannel);
+    var toWrite = resp['message'];
+  		if (newtext) {
+      toWrite = newtext;
+      newtext = undefined;
   		}
-    CBots[i].write(toWrite,callback);
-    DBots[i = ( ( i + 1 ) %4)].sendMessage(config.botChannel, toWrite);
+    CBots[i].write(toWrite, callback);
+   
+    DBots[i = ((i + 1) % DBots.length)].sendMessage(config.botChannel, toWrite);
   }, config.bot_speed);
-    DBots[i].stopTyping(config.botChannel);
+  DBots[i].stopTyping(config.botChannel);
 };
 
 var commandsProcessed = 0, talkedToTimes = 0;
 
-Cleverbot.prepare(function(){
-  lastMessage = config.startMessage; callback({message:config.startMessage})
+Cleverbot.prepare(function () {
+  lastMessage = config.startMessage; callback({ message: config.startMessage })
 });
 
 DBots[i].on("message", (msg) => {
-  	if (!msg.content.startsWith(config.command_prefix))	return;
-  	if (msg.content.indexOf(" ") === 1 && msg.content.length > 2) msg.content = msg.content.replace(" ", "");
-  	let cmd = msg.content.split(" ")[0].substring(1).toLowerCase();
-  	let suffix = msg.content.substring(cmd.length + 2).trim();
-  	if (msg.content.startsWith(config.command_prefix)) {
+  if (!msg.content.startsWith(config.command_prefix)) return;
+  if (msg.content.indexOf(" ") === 1 && msg.content.length > 2) msg.content = msg.content.replace(" ", "");
+  let cmd = msg.content.split(" ")[0].substring(1).toLowerCase();
+  let suffix = msg.content.substring(cmd.length + 2).trim();
+  if (msg.content.startsWith(config.command_prefix)) {
   		if (commands.hasOwnProperty(cmd)) {
-  			if (!msg.channel.isPrivate)
-  			execCommand(msg, cmd, suffix);
+      if (!msg.channel.isPrivate)
+        execCommand(msg, cmd, suffix);
   		}
-  	}
+  }
 });
 
 /* COMMANDS | START */
@@ -48,7 +55,7 @@ var commands = {
     desc: "Sends a PM with all commands that can be used",
     usage: "[command]",
     deleteCommand: true, shouldDisplay: false, cooldown: 1,
-    process: function(DBots, msg, suffix) {
+    process: function (DBots, msg, suffix) {
       let toSend = [];
       if (!suffix) {
         toSend.push("Use `" + config.command_prefix + "help <command name>` to get more info on a command.\n");
@@ -61,7 +68,7 @@ var commands = {
         toSend = toSend.join('');
         if (toSend.length >= 1990) {
           DBots[i].sendMessage(msg.author, toSend.substr(0, 1990).substr(0, toSend.substr(0, 1990).lastIndexOf('\n\t')) + "```"); //part 1
-          setTimeout(() => {DBots[i].sendMessage(msg.author, "```glsl" + toSend.substr(toSend.substr(0, 1990).lastIndexOf('\n\t')) + "```");}, 1000); //2
+          setTimeout(() => { DBots[i].sendMessage(msg.author, "```glsl" + toSend.substr(toSend.substr(0, 1990).lastIndexOf('\n\t')) + "```"); }, 1000); //2
         } else DBots[i].sendMessage(msg.author, toSend + "```"); DBots[i].sendMessage(msg, "**" + msg.author.username + "** I have sent you help in PM 📬");
       } else {
         suffix = suffix.toLowerCase();
@@ -71,39 +78,39 @@ var commands = {
           else if (commands[suffix].hasOwnProperty("desc")) toSend.push(commands[suffix].desc); //else usse the desc
           DBots[i].sendMessage(msg, toSend);
         } else
-          DBots[i].sendMessage(msg, "Command `" + suffix + "` not found.", (erro, wMessage) => { DBots[i].deleteMessage(wMessage, {"wait": 10000}); });
+          DBots[i].sendMessage(msg, "Command `" + suffix + "` not found.", (erro, wMessage) => { DBots[i].deleteMessage(wMessage, { "wait": 10000 }); });
       }
     }
   },
   "restart": {
-		desc: "Restart the bots to say something different", usage: "<sentence|word>",
-		process: function (DBots, msg, suffix) {
+    desc: "Restart the bots to say something different", usage: "<sentence|word>",
+    process: function (DBots, msg, suffix) {
       if (msg.channel.permissionsOf(msg.author).hasPermission("manageServer")) {
-      var nexttext = msg.content.substring(8).trim();
-          CBots = [new Cleverbot,new Cleverbot,new Cleverbot,new Cleverbot];
-      if(nexttext.length == 0) {
-        nexttext = lastMessage;
-      } else {
-        lastMessage = nexttext;
-      }
-      newtext = nexttext;
-    } else DBots[i].sendMessage(msg, "⚠ Access Denied `Permission Required - manageServer`");
-		}
-	},
+        var nexttext = msg.content.substring(8).trim();
+        CBots = [new Cleverbot, new Cleverbot, new Cleverbot, new Cleverbot];
+        if (nexttext.length == 0) {
+          nexttext = lastMessage;
+        } else {
+          lastMessage = nexttext;
+        }
+        newtext = nexttext;
+      } else DBots[i].sendMessage(msg, "⚠ Access Denied `Permission Required - manageServer`");
+    }
+  },
   "checkhost": {
-		desc: "Checks who is hosting", usage: "",
-		process: function (DBots, msg, suffix) {
+    desc: "Checks who is hosting", usage: "",
+    process: function (DBots, msg, suffix) {
       DBots[i].sendMessage(msg.channel, config.host)
-		}
-	},
+    }
+  },
   "vote": {
-		desc: "Vote to restart the bots", usage: "",
-		process: function (DBots, msg, suffix) {
-      if (votes == config.voteThreshold){
+    desc: "Vote to restart the bots", usage: "",
+    process: function (DBots, msg, suffix) {
+      if (votes == config.voteThreshold) {
         newtext = lastMessage;
         voters = [];
         votes = 0;
-        CBots = [new Cleverbot,new Cleverbot,new Cleverbot,new Cleverbot];
+        CBots = [new Cleverbot, new Cleverbot, new Cleverbot, new Cleverbot];
         DBots[i].sendMessage(msg.channel, "Cleverbutts *should* be restarted.")
       }
       if (voters.includes(msg.sender.id)) {
@@ -114,64 +121,50 @@ var commands = {
         DBots[i].sendMessage(msg.channel, "**" + remainingvotes + "** more votes are required to restart.");
         ++votes
       }
-		}
-	},
+    }
+  },
   "shutdown": {
-		desc: "Turns off the bots (and reboots if using script)", usage: "<sentence|word>",
-		process: function (DBots, msg, suffix) {
-      var startMSG = msg.content.substring(15,2000).trim();
-      if(startMSG.length == 0){
-      startMSG = lastMessage;
+    desc: "Turns off the bots (and reboots if using script)", usage: "<sentence|word>",
+    process: function (DBots, msg, suffix) {
+      var startMSG = msg.content.substring(15, 2000).trim();
+      if (startMSG.length == 0) {
+        startMSG = lastMessage;
       } else {
-      lastMessage = startMSG;
+        lastMessage = startMSG;
       }
       if (msg.channel.permissionsOf(msg.author).hasPermission("manageServer")) {
-        if(startMSG != ""){
-          fs.readFile("./config.json", "utf8" , function(err,ctx){
+        if (startMSG != "") {
+          fs.readFile("./config.json", "utf8", function (err, ctx) {
             var parts = ctx.split(config.startMessage)
-              fs.writeFile("./config.json", parts[0] + startMSG + parts[1], function(){
-                process.exit()
-              });
+            fs.writeFile("./config.json", parts[0] + startMSG + parts[1], function () {
+              process.exit()
             });
-          }
-          else{
-            process.exit()
-          }
-        } else DBots[i].sendMessage(msg, "⚠ Access Denied `Permission Required - manageServer`");
-		}
-	}
+          });
+        }
+        else {
+          process.exit()
+        }
+      } else DBots[i].sendMessage(msg, "⚠ Access Denied `Permission Required - manageServer`");
+    }
+  }
 }
 /* COMMANDS | END */
 
 function execCommand(msg, cmd, suffix, type = "normal") {
-try {
-	commandsProcessed += 1;
-		if (type == "normal") {
+  try {
+    commandsProcessed += 1;
+    if (type == "normal") {
       commands[cmd].process(DBots, msg, suffix);
     }
-	} catch (err) { console.log(err.stack); }
+  } catch (err) { console.log(err.stack); }
 }
 
 
 /* IGNORE THIS PART IF YOU DON*T KNOW WHAT YOU'RE DOING */
-if (config.bot1){
-  DBots[0].on("ready", function(){console.log("[info] Bot 1 logged in as " + DBots[0].user.name + "#" + DBots[0].user.discriminator + " (" + DBots[0].user.id + ")")});
-  DBots[0].loginWithToken(config.bot1);
-} else return;
-
-if (config.bot2){
-  DBots[1].on("ready", function(){console.log("[info] Bot 2 logged in as " + DBots[1].user.name + "#" + DBots[1].user.discriminator + " (" + DBots[1].user.id + ")")});
-  DBots[1].loginWithToken(config.bot2);
-} else return;
-
-if (config.bot3){
-  DBots[2].on("ready", function(){console.log("[info] Bot 3 logged in as " + DBots[2].user.name + "#" + DBots[2].user.discriminator + " (" + DBots[2].user.id + ")")});
-  DBots[2].loginWithToken(config.bot3);
-} else return;
-
-if (config.bot4){
-  DBots[3].on("ready", function(){console.log("[info] Bot 4 logged in as " + DBots[3].user.name + "#" + DBots[3].user.discriminator + " (" + DBots[3].user.id + ")")});
-  DBots[3].loginWithToken(config.bot4);
-} else return;
+var botNum = -1
+for (var ii = 0; ii < DBots.length; ii++) {
+  DBots[ii].on("ready", function () { botNum++; console.log("[info] Bot " + botNum + " logged in as " + DBots[botNum].user.name + "#" + DBots[botNum].user.discriminator + " (" + DBots[botNum].user.id + ")") });
+  DBots[ii].loginWithToken(config.bots[ii]);
+}
 
 exports.commands = commands;

--- a/cleverbutts.js
+++ b/cleverbutts.js
@@ -19,10 +19,10 @@ var i = 0, callback = function callback(resp) {
   setTimeout(function (str1, str2) {
     DBots[i].startTyping(config.botChannel);
     var toWrite = resp['message'];
-  		if (newtext) {
+    if (newtext) {
       toWrite = newtext;
       newtext = undefined;
-  		}
+    }
     CBots[i].write(toWrite, callback);
 
     DBots[i = ((i + 1) % DBots.length)].sendMessage(config.botChannel, toWrite);
@@ -42,10 +42,10 @@ DBots[i].on("message", (msg) => {
   let cmd = msg.content.split(" ")[0].substring(1).toLowerCase();
   let suffix = msg.content.substring(cmd.length + 2).trim();
   if (msg.content.startsWith(config.command_prefix)) {
-  		if (commands.hasOwnProperty(cmd)) {
+    if (commands.hasOwnProperty(cmd)) {
       if (!msg.channel.isPrivate)
         execCommand(msg, cmd, suffix);
-  		}
+    }
   }
 });
 

--- a/config.json
+++ b/config.json
@@ -6,14 +6,12 @@
   "host":"AlexFlipnote",
 
   "_comment_":[
-    "If you're using 3 bots, leave bot4 and bot5 empty.",
-    "Also enter how many bots you're hosting",
+    "Place your bot tokens in bots, as many as you want",
     "bot_speed is in ms, so 5000 would be 5 sec delay on messages"
   ],
-  "bots_hosting":"4",
   "bot_speed":"3000",
-  "bot1":"",
-  "bot2":"",
-  "bot3":"",
-  "bot4":""
+  "bots": [
+    "token 1",
+    "token 2"
+  ]
 }


### PR DESCRIPTION
The number of bots used to be hardcoded. This lead to issues where some bots would fail to load, etc. This PR replaces the individual bot token entities in the config with a single `bots` array, where one puts all of their tokens. The bot dynamically creates discord/cleverbots in relation to how many tokens are provided. This means you can have as many or as little bots as you want, even just a single bot talking to itself (change this if needed).

Along the way, my IDE accidentally formatted the indentation of the script, and I didn't know how to undo it or want to start over again, so I made all the indentation consistent. 2 space indentation, spaces instead of tabs. I hope that's alright.
