### PR TITLE
bot header

### DIFF
--- a/cleverbutts.js
+++ b/cleverbutts.js
@@ -13,7 +13,7 @@ var Cleverbot = require('cleverbot-node')
 
 var botNum = 0
 for (var ii = 0; ii < config.bots.length; ii++) {
-  DBots.push(new Eris.Client(config.bots[ii]))
+  DBots.push(new Eris.Client("Bot " + config.bots[ii]))
   DBots[ii].on("ready", function () {
     if (++botNum == DBots.length) {
       ready()


### PR DESCRIPTION
Discord requires all bots authenticate with a bot header. This means you need 'Bot ' in front of your token. I just manually added it. May remove once/if eris supports this.
